### PR TITLE
Layout manager - Default layout and local storage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "chance": "^0.7.3",
     "lodash-deep": "^1.6.0",
     "mocha": "^2.1.0",
+    "mock-local-storage": "^1.0.5",
     "react-try-catch-render": "^1.0.0"
   },
   "peerDependencies": {},

--- a/src/js/stores/managers/layout-manager.js
+++ b/src/js/stores/managers/layout-manager.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 var hat = require('hat');
 var ReactGridUtils = require('react-grid-layout').utils;
 var LayoutComponentColumns = require('../../constants/layout-constants').ColumnTypes;
+var LayoutComponentConstants = require('../../constants/layout-constants').ComponentTypes;
 
 class LayoutManager {
     constructor() {
@@ -16,6 +17,9 @@ class LayoutManager {
 
         // APEP specified so we can adjust.
         this.defaultComponentStartingY = Infinity;
+
+        this.addComponent(LayoutComponentConstants.SceneList);
+        this.addComponent(LayoutComponentConstants.SceneMediaBrowser);
     }
 
     minimize(index, component) {

--- a/src/js/stores/managers/layout-manager.js
+++ b/src/js/stores/managers/layout-manager.js
@@ -18,8 +18,14 @@ class LayoutManager {
         // APEP specified so we can adjust.
         this.defaultComponentStartingY = Infinity;
 
-        this.addComponent(LayoutComponentConstants.SceneList);
-        this.addComponent(LayoutComponentConstants.SceneMediaBrowser);
+        var loadedLayout = this.getLayoutFromLocalStorage();
+
+        if(loadedLayout.length === 0) {
+            this.addComponent(LayoutComponentConstants.SceneList);
+            this.addComponent(LayoutComponentConstants.SceneMediaBrowser);
+        } else {
+            this.layout = loadedLayout;
+        }
     }
 
     minimize(index, component) {
@@ -91,6 +97,7 @@ class LayoutManager {
 
     setLayout(layout) {
         this.layout = layout;
+        this.saveLayoutToLocalStorage();
     }
 
     collapseRight(component) {
@@ -179,25 +186,26 @@ class LayoutManager {
             1);
     };
 
+    // APEP static method
     getLayoutFromLocalStorage() {
         var parsedLayout = JSON.parse(localStorage.getItem('layout')) || [];
         if (parsedLayout.length < 1) {
             return [];
         } else {
+            // APEP TODO Values of Infinity get converted to nulls in local storage.  Must write test to fix
             return parsedLayout;
         }
     }
 
-    saveLayoutToLocalStorage(newLayout) {
-        // APEP TODO Ask why in a save to local storage are we also applying a delta to our state.
-        _.each(newLayout, function (item) {
+    // APEP TODO Ask why in a save to local storage are we also applying a delta to our state.
+    saveLayoutToLocalStorage() {
+        _.each(this.layout, function (item) {
             if (item.state === "default") {
                 item._w = item.w;
                 item._h = item.h;
             }
         });
-        this.layout = newLayout;
-        localStorage.setItem("layout", JSON.stringify(newLayout))
+        localStorage.setItem("layout", JSON.stringify(this.layout))
     }
 
     findNeighbours(component, leftOrRightColumn) {

--- a/test/stores/managers/test-layout-manager.js
+++ b/test/stores/managers/test-layout-manager.js
@@ -8,21 +8,44 @@ var LayoutComponentConstants = require('../../../src/js/constants/layout-constan
 var LayoutComponentColumns = require('../../../src/js/constants/layout-constants').ColumnTypes;
 
 describe('LayoutManager', function() {
+
    describe('constructor', function() {
 
        it('should setup the default state', function() {
            var manager = new LayoutManager();
 
-           assert(Array.isArray(manager.layout), "We have an empty array");
+           assert(Array.isArray(manager.layout), "We have an layout array defined");
            assert(manager.cols === 30, "We have a hardcoded fix number of cols")
        });
 
        // APEP TODO it.should use local storage....
+
+       it('should setup a basic layout', function() {
+           var manager = new LayoutManager();
+
+           assert(Array.isArray(manager.layout), "We have an layout array defined");
+
+           assert(manager.layout.length === 2, "We have two components by default");
+
+           var sceneListComponent = _.filter(manager.layout, function(comp){
+               return comp.type === LayoutComponentConstants.SceneList;
+           });
+           assert(Array.isArray(sceneListComponent));
+           assert(sceneListComponent.length === 1);
+
+           var mediaBrowserComponent = _.filter(manager.layout, function(comp){
+               return comp.type === LayoutComponentConstants.SceneMediaBrowser;
+           });
+           assert(Array.isArray(mediaBrowserComponent));
+           assert(mediaBrowserComponent.length === 1);
+       });
    });
 
    describe('calculateStartingPositionXForNewComponent', function() {
         it('should estimate the X position using the number of layout items added', function() {
             var manager = new LayoutManager();
+
+            manager.layout = []; // APEP remove default added components
 
             assert(manager.calculateStartingPositionXForNewComponent() === 0, "With no components added we will always get 0");
 
@@ -35,6 +58,8 @@ describe('LayoutManager', function() {
    describe('addComponent {type: "LayoutComponentConstants.ComponentTypes"}', function() {
         it('should add the component of the correct type with valid defaults', function() {
             var manager = new LayoutManager();
+
+            manager.layout = []; // APEP remove default added components
 
             manager.addComponent(LayoutComponentConstants.SceneMediaBrowser);
 
@@ -65,6 +90,7 @@ describe('LayoutManager', function() {
        beforeEach(function() {
             this.manager = new LayoutManager();
             this.manager.defaultComponentStartingY = 0;
+            this.manager.layout = []; // APEP remove default added components
        });
 
        it('should find no neighbours when no component is given to the method', function() {
@@ -157,6 +183,7 @@ describe('LayoutManager', function() {
        beforeEach(function() {
            this.manager = new LayoutManager();
            this.manager.defaultComponentStartingY = 0;
+           this.manager.layout = []; // APEP remove default added components
        });
 
        it('finds none when no items are in the layout', function() {
@@ -187,6 +214,7 @@ describe('LayoutManager', function() {
        beforeEach(function() {
            this.manager = new LayoutManager();
            this.manager.defaultComponentStartingY = 0;
+           this.manager.layout = []; // APEP remove default added components
        });
 
        /*
@@ -246,6 +274,7 @@ describe('LayoutManager', function() {
         beforeEach(function() {
             this.manager = new LayoutManager();
             this.manager.defaultComponentStartingY = 0;
+            this.manager.layout = []; // APEP remove default added components
         });
 
         it('should shrink the middle component when expanding a previously collapsed component', function() {
@@ -293,6 +322,7 @@ describe('LayoutManager', function() {
        beforeEach(function() {
            this.manager = new LayoutManager();
            this.manager.defaultComponentStartingY = 0;
+           this.manager.layout = []; // APEP remove default added components
        });
 
        it('should expand the middle when the RHS comp is collapsed', function() {
@@ -317,6 +347,7 @@ describe('LayoutManager', function() {
        beforeEach(function() {
            this.manager = new LayoutManager();
            this.manager.defaultComponentStartingY = 0;
+           this.manager.layout = []; // APEP remove default added components
        });
 
        it('should shrink the middle when the RHS comp is expanded', function() {

--- a/test/stores/managers/test-layout-manager.js
+++ b/test/stores/managers/test-layout-manager.js
@@ -6,10 +6,19 @@ var chance = require('chance').Chance();
 var LayoutManager = require('../../../src/js/stores/managers/layout-manager');
 var LayoutComponentConstants = require('../../../src/js/constants/layout-constants').ComponentTypes;
 var LayoutComponentColumns = require('../../../src/js/constants/layout-constants').ColumnTypes;
+var ls = require('mock-local-storage');
 
 describe('LayoutManager', function() {
 
    describe('constructor', function() {
+
+       before(function() {
+           localStorage.clear();
+       });
+
+       after(function() {
+           localStorage.clear();
+       });
 
        it('should setup the default state', function() {
            var manager = new LayoutManager();
@@ -38,6 +47,63 @@ describe('LayoutManager', function() {
            });
            assert(Array.isArray(mediaBrowserComponent));
            assert(mediaBrowserComponent.length === 1);
+       });
+
+       it('should use the local storage layout if it exists', function() {
+           var manager = new LayoutManager();
+           manager.addComponent(LayoutComponentConstants.Graph);
+           // APEP Hack for now, Infinity breaks it.
+           _.forEach(manager.layout, function(component){
+               component.y = 0;
+           });
+           manager.saveLayoutToLocalStorage();
+
+           var newManager = new LayoutManager();
+
+           assert(_.isEqual(newManager.layout, manager.layout));
+       });
+   });
+
+   describe('local storage tests', function() {
+
+       afterEach(function() {
+          localStorage.clear();
+       });
+
+       it('should be able to save to local storage', function() {
+
+           assert(localStorage.length === 0, "The local storage is empty ready for the test");
+
+           var manager = new LayoutManager();
+
+           assert(Array.isArray(manager.layout), "We have an layout array defined");
+
+           manager.saveLayoutToLocalStorage();
+
+           assert(localStorage.length === 1);
+       });
+
+       it('should be able to load from local storage', function() {
+           assert(localStorage.length === 0, "The local storage is empty ready for the test");
+
+           var manager = new LayoutManager();
+
+           assert(Array.isArray(manager.layout), "We have an layout array defined");
+
+           manager.addComponent(LayoutComponentConstants.Graph);
+
+           // APEP Hack for now, Infinity breaks it.
+           _.forEach(manager.layout, function(component){
+              component.y = 0;
+           });
+
+           manager.saveLayoutToLocalStorage();
+
+           assert(localStorage.length === 1);
+
+           var layoutFromLocalStorage = manager.getLayoutFromLocalStorage();
+
+           assert(_.isEqual(layoutFromLocalStorage, manager.layout));
        });
    });
 


### PR DESCRIPTION
Added back in a default layout and usage of local storage.

Local storage is first candidate during constructor, if we successfully load a layout we use it.  If not we provide a default layout (the default layout in this pull request is subject to change but won't need a pull request).

Every setLayout via updates from the user is saved back to local storage.