### PR TITLE
Clearing the outstanding interval before the component is unmounted

### DIFF
--- a/src/js/components/viewer/random-visual-player.jsx
+++ b/src/js/components/viewer/random-visual-player.jsx
@@ -119,6 +119,9 @@ var RandomVisualPlayer = React.createClass({
         }
 
     },
+    componentWillUnmount:function(){
+        clearInterval(this.state.loadMediaObjectInterval);
+    },
     componentDidMount: function () {
         console.log("refs",this.refs,this.props.sceneStyle)
         var self = this;


### PR DESCRIPTION
Simple solution, we have a state containing the loadMediaObject interval, and we clear it before unmounting the component. This resolves the issue of state changes being attempted to a component that does not exist 