### PR TITLE
A fix to attaching events to the rectangle shared between the ceramic…

### DIFF
--- a/src/js/components/graphs/thumbnail-components/rectangle.jsx
+++ b/src/js/components/graphs/thumbnail-components/rectangle.jsx
@@ -67,13 +67,13 @@ var Rectangle = React.createClass({
             <image
                 className={classes}
                 x={this.state.x }  width={this.state.r*2}
-                y={this.state.y }        height={this.state.r*2}
+                y={this.state.y }  height={this.state.r*2}
                 href={thumb}
                 preserveAspectRatio={"xMinYMin slice"}
                 clipPath={clipVal}
-                onClick={this.props.eventHandler.bind(null, this.props.data)}
-                onMouseEnter={this.props.onMouseEnterH.bind(null,this.props.data)}
-                onMouseLeave={this.props.onMouseLeaveH.bind(null,this.props.data)}
+                onClick={this.props.eventHandler?this.props.eventHandler.bind(null, this.props.data):null}
+                onMouseEnter={this.props.onMouseEnterH?this.props.onMouseEnterH.bind(null,this.props.data):null}
+                onMouseLeave={this.props.onMouseLeaveH?this.props.onMouseLeaveH.bind(null,this.props.data):null}
             >
             </image>
         ):(
@@ -86,9 +86,9 @@ var Rectangle = React.createClass({
                 height={this.state.r*2}
                 fill={this.state.color}
                 clipPath={clipVal}
-                onMouseEnter={this.props.onMouseEnterH.bind(null,this.props.data)}
-                onMouseLeave={this.props.onMouseLeaveH.bind(null,this.props.data)}
-             onClick={this.props.eventHandler.bind(null, this.props.data)}
+                onClick={this.props.eventHandler?this.props.eventHandler.bind(null, this.props.data):null}
+                onMouseEnter={this.props.onMouseEnterH?this.props.onMouseEnterH.bind(null,this.props.data):null}
+                onMouseLeave={this.props.onMouseLeaveH?this.props.onMouseLeaveH.bind(null,this.props.data):null}
             >
             </rect>
         )

--- a/src/js/components/graphs/thumbnail-graph.jsx
+++ b/src/js/components/graphs/thumbnail-graph.jsx
@@ -257,6 +257,12 @@ var ThumbGraph = React.createClass({
         });
 
     },
+    setupAllNodes:function(data,p){
+       var self =this;
+       _.each(data.nodes,function(node){
+          node.r=15;
+       });
+    },
     _nodes: function (list, sceneList) {
         var self = this;
         for (var listIndex in list) {
@@ -290,6 +296,7 @@ var ThumbGraph = React.createClass({
             self.setupRootNodes(data, properties);
             self.setupSceneNodes(data, properties);
             self.setupImageNodes(data,properties);
+            self.setupAllNodes(data,properties);
             self.setupCircularNodeFormation(data,properties)
 
             self.setState({data:data});
@@ -308,9 +315,9 @@ var ThumbGraph = React.createClass({
                     'rotate':node.highlighted,
                 });
                 return (<g key={i} className={classes} >
-                    <clipPath id={"clipC"+i}>
+              {/*      <clipPath id={"clipC"+i}>
                         <circle r="50" cx={node.cx} cy={node.cy}/>
-                    </clipPath>
+                    </clipPath>*/}
                     <Rectangle data={node}  eventHandler={self.tapHandler} clip={"clipC"+i}></Rectangle>
                 </g>)
             });


### PR DESCRIPTION
… and thumbnail graph.

An event will be attached if it exists in the properties send to the rectangle element.
An extra size addition to accomodate the changes to the values that the rectangle transition can handle

This an improvement to the merge done that fixes the thumbnail graph not drawing due to the missing mouseover events.