### PR TITLE
Turn back on and improve mo selection from clicking in the editor.

### DIFF
--- a/src/js/actions/scene-actions.js
+++ b/src/js/actions/scene-actions.js
@@ -16,10 +16,13 @@ var toastr = require('toastr');
 
 var SceneActions = {
 
-    changeMediaObjectFocus:function(index){
+    // APEP fromMonacoEditor allows the editor to set the focus has come from itself
+    // Any other component should be false
+    changeMediaObjectFocus:function(index, fromMonacoEditor = false){
         AppDispatcher.handleViewAction({
             type: ActionTypes.COMP_MEDIA_OBJECT_FOCUS_SWITCH,
-            index: index
+            index: index,
+            fromMonacoEditor: fromMonacoEditor
         });
     },
     changeFocus:function(itemType){

--- a/src/js/components/pages/adjustable-grid.jsx
+++ b/src/js/components/pages/adjustable-grid.jsx
@@ -80,7 +80,7 @@ var RespGrid = React.createClass({
                                             focusedMediaObject={this.state.data.focusedMediaObject}
                                             _id={self.state.data.scene._id}>
                     </SceneMediaBrowser>
-                )
+                );
                 break;
             case LayoutComponentTypes.SceneEditorGUI:
                 return (
@@ -99,14 +99,16 @@ var RespGrid = React.createClass({
                         focusedMediaObject={this.state.data.focusedMediaObject}
                         _id={self.state.data.scene._id}
                     />
-                )
+                );
                 break;
             case LayoutComponentTypes.SceneEditor:
-                return ( <LayoutMonacoTextEditor isLayout={true} focusedMediaObject={this.state.data.focusedMediaObject}
+                return ( <LayoutMonacoTextEditor isLayout={true}
+                                                 focusedMediaObject={this.state.data.focusedMediaObject}
+                                                 focusFromMonacoEditor={this.state.data.fromMonacoEditor}
                                                  _id={this.state.data.scene._id}
                                                  focusHandler={SceneActions.changeMediaObjectFocus}>
                     </LayoutMonacoTextEditor>
-                )
+                );
                 break;
             default:
                 return null;

--- a/src/js/components/pages/layout-text-editor.jsx
+++ b/src/js/components/pages/layout-text-editor.jsx
@@ -189,7 +189,7 @@ var SceneMonacoTextEditor = React.createClass({
             var isInTags = monaco.Range.containsRange(tagRange, selectionRange);
 
             if(isInTags)
-                this.props.focusHandler(parseInt(m));
+                SceneActions.changeMediaObjectFocus(parseInt(m), true);
         }
 
     },
@@ -243,7 +243,6 @@ var SceneMonacoTextEditor = React.createClass({
     onDidMount: function(editor, monaco) {
         // console.log('MONACO - onDidMount', editor);
 
-
         editor.addAction({
             // An unique identifier of the contributed action.
             id: 'copy-command',
@@ -277,8 +276,7 @@ var SceneMonacoTextEditor = React.createClass({
         this._onChange();
 
         // this.refs.monaco.editor.onDidChangeCursorPosition(this.onChangeCursorPosition);
-        //
-        // this.refs.monaco.editor.onDidChangeCursorSelection(this.onTextSelection)
+        this.refs.monaco.editor.onDidChangeCursorSelection(this.onTextSelection)
     },
 
     shouldComponentUpdate: function(nextProps, nextState) {
@@ -322,8 +320,12 @@ var SceneMonacoTextEditor = React.createClass({
                 console.log("No selection for media object available");
                 return;
             }
-            this.refs.monaco.editor.setPosition(match.getStartPosition());
-            this.refs.monaco.editor.revealPosition(match.getStartPosition());
+
+            // APEP only set the position and focus of the text editor if the focus event has not come from the editor itself.
+            if(!this.props.focusFromMonacoEditor){
+                this.refs.monaco.editor.setPosition(match.getStartPosition());
+                this.refs.monaco.editor.revealPosition(match.getStartPosition());
+            }
         }
 
     },

--- a/src/js/stores/grid-store.js
+++ b/src/js/stores/grid-store.js
@@ -26,7 +26,8 @@ var gridState = {
     focusedType: null,
     poppedOutComponent: null,
     focusedMediaObject: null,
-    layoutManager: new LayoutManager()
+    layoutManager: new LayoutManager(),
+    fromMonacoEditor: false
 };
 
 changeFocus = function (type) {
@@ -34,7 +35,8 @@ changeFocus = function (type) {
     //AngelP: this is done to reset the focused media object when the scene changes
     gridState.focusedMediaObject = null;
 };
-changeMediaObjectFocus = function (index) {
+changeMediaObjectFocus = function (index, fromMonacoEditor) {
+    gridState.fromMonacoEditor = fromMonacoEditor;
     gridState.focusedMediaObject = index;
 };
 
@@ -154,7 +156,7 @@ var GridStore = assign({}, EventEmitter.prototype, {
                 GridStore.emitChange();
                 break;
             case ActionTypes.COMP_MEDIA_OBJECT_FOCUS_SWITCH:
-                changeMediaObjectFocus(action.index);
+                changeMediaObjectFocus(action.index, action.fromMonacoEditor);
                 GridStore.emitChange();
                 break;
             case ActionTypes.ADD_COMPONENT:


### PR DESCRIPTION
Process the editors selected position to focus media.
Added some constraints that only if a focus media is selected outside the editor, do we move the cursor.