### PR TITLE
Drag focus reset bugfix

### DIFF
--- a/src/js/stores/grid-store.js
+++ b/src/js/stores/grid-store.js
@@ -32,10 +32,6 @@ var gridState = {
 
 changeFocus = function (type) {
     gridState.focusedType = type;
-
-    //AngelP: this is done to reset the focused media object when the scene changes
-    //MK: Removed to fix on drag bug - already handled in scene focus change
-    //gridState.focusedMediaObject = null;
 };
 
 changeMediaObjectFocus = function(index){

--- a/src/js/stores/grid-store.js
+++ b/src/js/stores/grid-store.js
@@ -32,9 +32,12 @@ var gridState = {
 
 changeFocus = function (type) {
     gridState.focusedType = type;
+
     //AngelP: this is done to reset the focused media object when the scene changes
-    gridState.focusedMediaObject  = null;
+    //MK: Removed to fix on drag bug - already handled in scene focus change
+    //gridState.focusedMediaObject = null;
 };
+
 changeMediaObjectFocus = function(index){
     gridState.focusedMediaObject = index;
 };

--- a/src/js/utils/connection-cache.js
+++ b/src/js/utils/connection-cache.js
@@ -26,6 +26,7 @@ groupNames.set(113, "Yibing");
 groupNames.set(114, "Mirroring Life");
 groupNames.set(115, "DPL");
 groupNames.set(116, "Salford Press");
+groupNames.set(117, "Textiles");
 
 function getCookie(name) {
     var value = "; " + document.cookie;


### PR DESCRIPTION
Fixes bug where focus is reset on adding/moving components to the grid.

focuseMediaObject is already cleared during scene change.