### PR TITLE
Fix bug where meida focus is reset on adding/dragging grid component

### DIFF
--- a/src/js/stores/grid-store.js
+++ b/src/js/stores/grid-store.js
@@ -32,9 +32,8 @@ var gridState = {
 
 changeFocus = function (type) {
     gridState.focusedType = type;
-    //AngelP: this is done to reset the focused media object when the scene changes
-    gridState.focusedMediaObject = null;
 };
+
 changeMediaObjectFocus = function (index, fromMonacoEditor) {
     gridState.fromMonacoEditor = fromMonacoEditor;
     gridState.focusedMediaObject = index;


### PR DESCRIPTION
Scene change handler already resets focused media object, this changeFocus event is fired on any grid component change.