### PR TITLE
Allow maxFiles to reset without the component needing to be reinitial…

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "react-monaco-editor": "^0.7.3",
     "react-newline-to-break": "^1.0.6",
     "react-rectangle": "1.3.3",
-    "react-resumable-js": "^1.1.19",
+    "react-resumable-js": "https://github.com/aaronpcz/ReactResumableJS#1.1.27",
     "react-rnd": "7.1.2",
     "react-router": "^2.8.1",
     "react-select-plus": "^1.0.0-rc.10",

--- a/src/js/actions/scene-actions.js
+++ b/src/js/actions/scene-actions.js
@@ -333,6 +333,18 @@ var SceneActions = {
         }
     },
 
+    uploadingAssets: function() {
+        AppDispatcher.handleViewAction({
+            type: ActionTypes.UPLOAD_MEDIA_ATTEMPT,
+        });
+    },
+
+    uploadingAssetsFinished: function() {
+        AppDispatcher.handleViewAction({
+            type: ActionTypes.UPLOAD_MEDIA_FINISHED,
+        });
+    },
+
     finaliseResumableUploadAsset: function (sceneId, file, resumableFile, cb) {
         var alertId = hat();
 

--- a/src/js/components/pages/scene-media-browser.jsx
+++ b/src/js/components/pages/scene-media-browser.jsx
@@ -3,6 +3,7 @@ var _ = require('lodash');
 var SceneStore = require('../../stores/scene-store');
 var SceneSavedStore = require('../../stores/scene-saving-store');
 var GridStore = require("../../stores/grid-store");
+var AddMediaObjectStore = require("../../stores/add-media-object-store");
 var HubSendActions = require('../../actions/hub-send-actions');
 var SceneActions = require('../../actions/scene-actions');
 var TagUnion = require('../tag-union.jsx');
@@ -29,7 +30,7 @@ var SceneMediaBrowser = React.createClass({
     getStateFromStores: function() {
         return {
             scene: SceneStore.getScene(this.props._id),
-            uploading: false,
+            uploading: AddMediaObjectStore.mediaUploading(),
             savedStatus: SceneSavedStore.getSceneSaved()
         };
     },
@@ -37,18 +38,15 @@ var SceneMediaBrowser = React.createClass({
         SceneStore.addChangeListener(this._onChange);
         SceneSavedStore.addChangeListener(this._onChange);
         GridStore.addChangeListener(this._onFocusChange);
+        AddMediaObjectStore.addChangeListener(this._onChange);
     },
     componentWillUnmount: function () {
         SceneStore.removeChangeListener(this._onChange);
         SceneSavedStore.removeChangeListener(this._onChange);
-        GridStore.removeChangeListener(this._onFocusChange)
+        GridStore.removeChangeListener(this._onFocusChange);
+        AddMediaObjectStore.removeChangeListener(this._onChange);
     },
-    uploadStarted: function() {
-        this.setState({uploading: true});
-    },
-    uploadEnded: function() {
-        this.setState({uploading: false});
-    },
+
     deleteSceneHandler: function(event) {
         if (confirm('Deleting a scene will remove all associated images and tags.\n\nAre you sure?')) {
             HubSendActions.deleteScene(this.state.scene._id);
@@ -79,8 +77,7 @@ var SceneMediaBrowser = React.createClass({
                     </Loader>
                 </div>
 
-                <AddMediaObject scene={this.state.scene} uploadStarted={this.uploadStarted}
-                                uploadEnded={this.uploadEnded}/>
+                <AddMediaObject scene={this.state.scene}/>
 
                 <div className="thumbs-and-json">
                     <div className="flex-container">

--- a/src/js/constants/scene-constants.js
+++ b/src/js/constants/scene-constants.js
@@ -46,6 +46,10 @@ module.exports = {
         ADD_MEDIA_ATTEMPT: null,
         ADD_MEDIA_SUCCESS: null,
         ADD_MEDIA_FAILED: null,
+
+        UPLOAD_MEDIA_ATTEMPT: null,
+        UPLOAD_MEDIA_FINISHED: null,
+
         REMOVE_MEDIA_OBJECT: null,
         LIST_SCENES_ATTEMPT: null,
         RECIEVE_SCENE_LIST: null,

--- a/src/js/stores/add-media-object-store.js
+++ b/src/js/stores/add-media-object-store.js
@@ -11,10 +11,16 @@ var toastr = require('toastr');
 var _loading = false;
 var _inputValue = '';
 
+var _mediaUploading = false;
+
 var AddMediaObjectStore = assign({}, EventEmitter.prototype, {
 	loading: function() {
 		return _loading;
 	},
+
+    mediaUploading: function() {
+	    return _mediaUploading;
+    },
 
     inputValue: function() {
         return _inputValue;
@@ -35,7 +41,16 @@ var AddMediaObjectStore = assign({}, EventEmitter.prototype, {
 	dispatcherIndex: AppDispatcher.register(function(payload){
         var action = payload.action; // this is our action from handleViewAction
 
-        switch(action.type){
+        switch(action.type) {
+
+            case ActionTypes.UPLOAD_MEDIA_ATTEMPT:
+                _mediaUploading = true;
+                break;
+
+            case ActionTypes.UPLOAD_MEDIA_FINISHED:
+                _mediaUploading = false;
+                break;
+
             case ActionTypes.ADD_MEDIA_ATTEMPT:
             	_inputValue = action.value;
                 _loading = true;
@@ -48,7 +63,7 @@ var AddMediaObjectStore = assign({}, EventEmitter.prototype, {
                 break;
 
             case ActionTypes.ADD_MEDIA_FAILED:
-                console.log(action)
+                console.log(action);
                 switch (action.value.status){
                     case 404:
                         toastr.warning('The media you are trying to add was not found');


### PR DESCRIPTION
…ised.

Requires changes to the underlying react wrapper for the resumable-js code.
Currently these changes live in a forked version of the lib.
A pull request will be made to incorporate the changes into the lib if possible.
We may need to adjust slightly to allow the functionality we require to be toggleable.

**Reason for the fix**
- The upload component was hitting the maxFiles if a number of files are uploaded in batches without the component be deconstructed and constructed again.  The reason for this is the upload resumable js library assumed the uploader would be used then destroyed, such as creating a profile in a website and uploading a profile picture.  As this is different to our use case, the same upload component might live for much longer periods of time and be used to ingest a lot of content during it's lifetime.

The library has been modified to hook into the onComplete function, allowing us to know when all files have been uploaded rather than just after one.  We know use this improved hook for the overlay for the component.  In the react resumable js, this hook is also now used to clear the resumable js state after complete upload, so the progress bar and maxFiles state are correctly managed.  In our use case, once an upload has been complete, the maxFiles should reset, this is usually the opposite to what you'd want for say uploading profile pictures.