### PR TITLE
Resolve the component update check for the monaco editor.

### DIFF
--- a/src/js/components/pages/adjustable-grid.jsx
+++ b/src/js/components/pages/adjustable-grid.jsx
@@ -67,6 +67,8 @@ var RespGrid = React.createClass({
 
         ViewLayoutActions.layoutChange(mergedList);
     },
+
+    // APEP TODO review the isLayout property, seems like it is unused in every component but one...
     getComponent: function (item) {
         var self = this;
         switch (item.type) {

--- a/src/js/components/pages/scene-editor-gui.jsx
+++ b/src/js/components/pages/scene-editor-gui.jsx
@@ -9,9 +9,9 @@ var FontAwesome = require('react-fontawesome');
 var Rectangle = require('react-rectangle');
 var ImageLoader = require('react-imageloader');
 
-var saveTimeout = null;
-
 var SceneEditorGUI = React.createClass({
+
+    saveTimeout: null,
 
     getInitialState: function () {
         return _.extend(this.getStateFromStores(), {
@@ -52,9 +52,9 @@ var SceneEditorGUI = React.createClass({
     },
 
     componentWillUnmount: function () {
-        if (saveTimeout) {
+        if (this.saveTimeout) {
             //this.saveToScene()
-            clearTimeout(saveTimeout);
+            clearTimeout(this.saveTimeout);
         }
         SceneStore.removeChangeListener(this._onChange);
         GridStore.removeChangeListener(this._onFocusChange)
@@ -248,10 +248,10 @@ var SceneEditorGUI = React.createClass({
     //schedules a save in 1 second. Avoids to many saves
     setSave() {
         console.log("SceneEditorGUI: Save Scheduled")
-        if (saveTimeout) {
-            clearTimeout(saveTimeout);
+        if (this.saveTimeout) {
+            clearTimeout(this.saveTimeout);
         }
-        saveTimeout = setTimeout(this.saveToScene, 1000);
+        this.saveTimeout = setTimeout(this.saveToScene, 1000);
     },
 
     saveToScene() {

--- a/src/js/components/pages/tag-editor.jsx
+++ b/src/js/components/pages/tag-editor.jsx
@@ -10,13 +10,13 @@ var AssetActions = require('../../actions/asset-actions');
 var FontAwesome = require('react-fontawesome');
 var ReactTags = require('react-tag-input').WithContext;
 
-//global save timeout
-var saveTimeout = null;
-
 //autosave timeout length - should be ~instant here to avoid missing tags
 const saveTimeoutLength = 100;
 
 var TagEditor = React.createClass({
+
+// instance variables
+    saveTimeout: null,
 
 //lifecycle
 
@@ -39,9 +39,9 @@ var TagEditor = React.createClass({
     },
 
     componentWillUnmount: function () {
-        if (saveTimeout) {
+        if (this.saveTimeout) {
             //this.saveToScene()
-            clearTimeout(saveTimeout);
+            clearTimeout(this.saveTimeout);
         }
         SceneStore.removeChangeListener(this._onChange);
         GridStore.removeChangeListener(this._onFocusChange)
@@ -59,10 +59,10 @@ var TagEditor = React.createClass({
 
     setSave() {
         console.log("TagEditor: Save Scheduled")
-        if (saveTimeout) {
-            clearTimeout(saveTimeout);
+        if (this.saveTimeout) {
+            clearTimeout(this.saveTimeout);
         }
-        saveTimeout = setTimeout(this.saveToScene, saveTimeoutLength);
+        this.saveTimeout = setTimeout(this.saveToScene, saveTimeoutLength);
     },
 
     saveToScene() {

--- a/src/js/components/scene-editor/media-preview-player.jsx
+++ b/src/js/components/scene-editor/media-preview-player.jsx
@@ -88,7 +88,6 @@ var MediaObjectPreviewPlayer = React.createClass({
     },
     setupState: function (props) {
         this.setState(this.getInitialState());
-        console.log("componentWillReceiveProps", props)
         if (props) {
             this.previewMediaObject(props);
         }
@@ -99,7 +98,6 @@ var MediaObjectPreviewPlayer = React.createClass({
     },
 
     componentWillReceiveProps: function (nextProps) {
-
         this.setupState(nextProps);
     },
     componentWillUnmount: function () {
@@ -109,7 +107,7 @@ var MediaObjectPreviewPlayer = React.createClass({
     render: function () {
         var reactStyle = {};
 
-        if (this.props.scene != undefined) {
+        if (this.props.scene !== undefined) {
             reactStyle = this._cssToReactCSS(this.props.scene.style);
         }
 


### PR DESCRIPTION
The previous method of checking the monaco text editor value required a JSON parse.  This caused any users mid update potentially throw a syntax error and the text editor would reset to pre-syntax error state causing the bug.

During updates I also refactored the saveTimeout management for the components that track user changes over time and trigger saves.  I think this instance variable method is probably better suited rather than the global variables.  Might be worth some discussion.