### PR TITLE
Improve SceneID Copying

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "qrcode.react": "^0.6.1",
     "react": "^15.3.2",
     "react-bootstrap": "^0.31.1",
+    "react-copy-to-clipboard": "^5.0.1",
     "react-dnd": "^2.1.4",
     "react-dnd-html5-backend": "^2.1.2",
     "react-dom": "^15.3.2",

--- a/src/js/components/scene-selector.jsx
+++ b/src/js/components/scene-selector.jsx
@@ -13,6 +13,7 @@ var Modal = ReactBootstrap.Modal;
 //components
 var SelectPlus = require('react-select-plus').default;
 var FontAwesome = require('react-fontawesome');
+var ReactClipboard = require('react-copy-to-clipboard').CopyToClipboard;
 
 //utils
 var _ = require('lodash');
@@ -188,10 +189,13 @@ var SceneSelector = React.createClass({
                 <input
                   id="sceneIDbox"
                   className="inline-item"
-                  style={{width: "60%"}}
+                  style={{width: "50%", backgroundColor: "#F5F5F5", borderWidth: "2px"}}
                   value={this.state.sceneListFilter.value._id}
-                  disabled="true"
+                  readOnly="true"
                 />
+                <ReactClipboard text={this.state.sceneListFilter.value._id}>
+                  <button style={{width: "10%"}}>Copy</button>
+                </ReactClipboard>
               </div>
               <div>
                 <div className="inline-item" style={{marginBottom: "15px"}}>Scene Name:&nbsp;&nbsp;</div>


### PR DESCRIPTION
Change input type to readonly instead of disabled to allow text selection and add copy button.

We could consider adding a QR code in the space available in this modal as well