### PR TITLE
Remove the old audio tween utility.

### DIFF
--- a/src/js/utils/media-object/audio-media-object.js
+++ b/src/js/utils/media-object/audio-media-object.js
@@ -1,7 +1,6 @@
 'use strict';
 /*jshint browser:true */
 
-var TweenloopInterval = require('../tween-loop-interval');
 var soundCloud = require('../sound-cloud');
 var MediaObject = require('./media-object');
 var inherits = require('inherits');

--- a/src/js/utils/media-object/video-media-object.js
+++ b/src/js/utils/media-object/video-media-object.js
@@ -4,7 +4,6 @@
 var MediaObject = require('./media-object');
 
 var getVimeoId = require('../get-vimeo-id');
-var TweenloopInterval = require('../tween-loop-interval');
 var EmbeddedVimeoPlayer = require('../embedded-vimeo-player');
 var SceneActions = require('../../actions/scene-actions');
 var TWEEN = require('@tweenjs/tween.js');

--- a/src/js/utils/tween-loop-interval.js
+++ b/src/js/utils/tween-loop-interval.js
@@ -1,8 +1,0 @@
-'use strict';
-/*jshint browser:true */
-
-var TWEEN = require('@tweenjs/tween.js');
-
-module.exports = setInterval(function() {
-	TWEEN.update();
-}, 250);


### PR DESCRIPTION
Because it is required by the 2 media object types, it has been setting intervals and trying to update animation tweens.
This is handled differently now this method is surely likely to leak intervals over time...