### PR TITLE
Updated monaco editor from 0.7.3 to 0.9.0 , still heavily based on np…

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "react-image": "^1.3.1",
     "react-imageloader": "2.1.0",
     "react-measure": "^1.4.7",
-    "react-monaco-editor": "^0.7.3",
+    "react-monaco-editor": "^0.9.0",
     "react-newline-to-break": "^1.0.6",
     "react-rectangle": "1.3.3",
     "react-resumable-js": "git+https://github.com/aaronpcz/ReactResumableJS.git#1.1.27",

--- a/src/js/components/pages/layout-text-editor.jsx
+++ b/src/js/components/pages/layout-text-editor.jsx
@@ -421,7 +421,16 @@ var SceneMonacoTextEditor = React.createClass({
         var options = {
             selectOnLineNumbers: true,
             automaticLayout: true,
-            scrollBeyondLastLine: false
+            scrollBeyondLastLine: false,
+            folding:true,
+            showFoldingControls:'always',
+            matchBracket:true,
+            lightbulb:{
+                enabled:true
+            },
+            minimap:{
+                enabled:false
+            }
         };
 
         var requireConfig = {


### PR DESCRIPTION
…m installation and not causing browserify build issues.

Folding enabled, and some of the new defaul options of the react-monaco-editor have been taken off as well