### PR TITLE
Prototype version of monaco editor decorators.

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1157,3 +1157,16 @@ div.ReactTags__suggestions ul li.ReactTags__activeSuggestion {
     padding-left: 2px;
     padding-right: 2px;
 }
+
+.media-scene-mo-highlight-json-text {
+    color: red !important;
+    cursor: pointer;
+    text-decoration: underline;
+    font-weight: bold;
+    font-style: oblique;
+}
+.media-scene-mo-highlight-linenumber-bar {
+    background: lightblue;
+    width: 5px !important;
+    left: 3px;
+}


### PR DESCRIPTION
Allow decorators to be used to highlight specific parts of a JSON document.
REGEX for search is not fully wrapping a media object.
- Particularly challenging to get to work for every case.. authors are not strict and JSON is not strict.

This is not complete, the CSS written is extremely ugly and needs some input.