### PR TITLE
Aspect ratio player fix

### DIFF
--- a/src/js/components/viewer/random-visual-player.jsx
+++ b/src/js/components/viewer/random-visual-player.jsx
@@ -241,6 +241,7 @@ var RandomVisualPlayer = React.createClass({
             <div className="player" ref="player" style={this.props.sceneStyle}>
                 {q}
                 {cueMediaObjects}
+                {this.props.children}
             </div>
         );
     }

--- a/src/js/components/viewer/scene-listener.jsx
+++ b/src/js/components/viewer/scene-listener.jsx
@@ -332,16 +332,17 @@ var SceneListener = React.createClass({
                 <AspectRatio ratio={this.state.scene.aspect || "16:9"} offset={0}>
                     <div className={self.props.sceneViewer ? "mf-local-width scene-listener" : "scene-listener"} ref="scene_listener">
                         <Loader loaded={this.state.scene !== null}></Loader>
-                        <RandomVisualPlayer 
+                        <RandomVisualPlayer
                             sceneStyle={this.state.scene.style}
                             mediaQueue={this.state.mediaObjectQueue}
                             triggerMediaActiveTheme={this.triggerMediaActiveTheme}
                             removeMediaActiveThemesAfterDone={this.removeMediaActiveThemesAfterDone}
                             cuePointMediaObjects={this.state.cuePointMediaObjects}
-                            cueMediaObjectDoneHandler={this.cueMediaObjectDoneHandler}
-                        />
-                        {ThemeDisplay}
-                        {TagForm}
+                            cueMediaObjectDoneHandler={this.cueMediaObjectDoneHandler}>
+                            {ThemeDisplay}
+                            {TagForm}
+                        </RandomVisualPlayer>
+
                     </div>
                     <div></div>
                 </AspectRatio>


### PR DESCRIPTION
This fix leads to a discussion, how do we position the aspect ratio sized player in a web page that does not match (currently top left).

Do we want the theme and tag filters to be within the player or just bound to the parent of the players size.

Lets discuss tomorrow before merging. 