### PR TITLE
Resolved Monaco editor issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "reactify": "^1.1.1",
     "require-sdk": "0.0.2",
     "serve-static": "^1.6.3",
+    "sha1": "^1.1.1",
     "socket.io-client": "^1.3.5",
     "spin.js": "^2.0.2",
     "stripify": "^6.0.0",

--- a/src/js/components/scene-editor/layout-text-editor.jsx
+++ b/src/js/components/scene-editor/layout-text-editor.jsx
@@ -147,10 +147,12 @@ var SceneMonacoTextEditor = React.createClass({
     },
 
     saveSceneHistory: function (sceneJsonStringSha1Hash) {
+
+        // APEP avoid filling history, the lower the number the better.
+        // APEP ideally should be 1 or 2 to avoid race conditions
         if (this.state.sceneHistory.length > 4)
             this.state.sceneHistory.shift();
 
-        // APEP early entry of scene string for history check
         this.state.sceneHistory.push(sceneJsonStringSha1Hash);
     },
 
@@ -162,15 +164,14 @@ var SceneMonacoTextEditor = React.createClass({
                 return !sceneObj.hasOwnProperty("tags") || !sceneObj.hasOwnProperty("type");
             });
 
+            // APEP check to see if the author is currently typing a new media object by hand
             var shouldSave = mediaWithoutTagOrType.length === 0;
 
-            // APEP ensure we should save, previously the || logic was forcing unrequired saves
-            if (!_.isEqual(this.state.scene, newScene) && shouldSave) { //TODO ensure a save occurs for scene media without id - must update view with _id
+            if (!_.isEqual(this.state.scene, newScene) && shouldSave) {
 
-                // APEP early entry of scene string for history check
+                // Save a copy of the to be saved new scene, allows the component update cycle to skip updates to avoid race condition for moving cursor post save
                 this.saveSceneHistory(sha1(JSON.stringify(newScene)));
 
-                // APEP with early entry, the update from this specific text based update can be missed by update cycle
                 SceneActions.updateScene(newScene);
             }
 


### PR DESCRIPTION
_Make sure to clear cache after building source, it's even worth checking chrome dev tools - source to ensure it's updated with this fix._

Previous history attempt was not successful for a number of reasons.

(from commit messages)
Using sha1 and storing a short version history (list of last 4) of the scene that is opened in the editor.

sha1 used for reduced errors for equality checks (maybe a non issue but reliable)

History is appended now in two places, where the editor is forced update, ie an outside update, such as adding a new media object.  The history is also appended too when the editor itself tries to save a copy, this was prone until I used clone data at the point of save.  Without the clone and storing of the history, race conditions can lead to the editor updating mid authoring which are not required.
